### PR TITLE
feat: configure patters regex engine

### DIFF
--- a/jsonschema/Cargo.toml
+++ b/jsonschema/Cargo.toml
@@ -64,7 +64,7 @@ url = "2.5"
 uuid = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { version = "0.3", features = ["wasm_js"] }
 
 [dev-dependencies]
 bench_helpers = { path = "../bench_helpers" }

--- a/jsonschema/src/compilation/options.rs
+++ b/jsonschema/src/compilation/options.rs
@@ -552,7 +552,7 @@ impl CompilationOptions {
         self
     }
 
-    pub(crate) fn pattern_regex_engine(&self) -> &RegexEngine {
+    pub(crate) fn patterns_regex_engine(&self) -> &RegexEngine {
         &self.patterns_regex_engine
     }
 

--- a/jsonschema/src/compilation/options.rs
+++ b/jsonschema/src/compilation/options.rs
@@ -261,6 +261,107 @@ static META_SCHEMA_VALIDATORS: Lazy<AHashMap<schemas::Draft, JSONSchema>> = Lazy
     store
 });
 
+/// Fancy regex crate options
+#[derive(Clone, Default)]
+pub struct FancyRegexOptions {
+    /// Limit for how many times backtracking should be attempted for fancy regexes (where
+    /// backtracking is used). If this limit is exceeded, execution returns an error.
+    /// This is for preventing a regex with catastrophic backtracking to run for too long.
+    ///
+    /// Default is `1_000_000` (1 million).
+    pub backtrack_limit: Option<usize>,
+    /// Set the approximate size limit of the compiled regular expression.
+    ///
+    /// This option is forwarded from the wrapped `regex` crate. Note that depending on the used
+    /// regex features there may be multiple delegated sub-regexes fed to the `regex` crate. As
+    /// such the actual limit is closer to `<number of delegated regexes> * delegate_size_limit`.
+    pub delegate_size_limit: Option<usize>,
+    /// Set the approximate size of the cache used by the DFA.
+    ///
+    /// This option is forwarded from the wrapped `regex` crate. Note that depending on the used
+    /// regex features there may be multiple delegated sub-regexes fed to the `regex` crate. As
+    /// such the actual limit is closer to `<number of delegated regexes> *
+    /// delegate_dfa_size_limit`.
+    pub delegate_dfa_size_limit: Option<usize>,
+}
+
+/// Regex crate options
+#[derive(Clone, Default)]
+pub struct RegexOptions {
+    /// Sets the approximate size limit, in bytes, of the compiled regex.
+    ///
+    /// This roughly corresponds to the number of heap memory, in
+    /// bytes, occupied by a single regex. If the regex would otherwise
+    /// approximately exceed this limit, then compiling that regex will
+    /// fail.
+    ///
+    /// The main utility of a method like this is to avoid compiling
+    /// regexes that use an unexpected amount of resources, such as
+    /// time and memory. Even if the memory usage of a large regex is
+    /// acceptable, its search time may not be. Namely, worst case time
+    /// complexity for search is `O(m * n)`, where `m ~ len(pattern)` and
+    /// `n ~ len(haystack)`. That is, search time depends, in part, on the
+    /// size of the compiled regex. This means that putting a limit on the
+    /// size of the regex limits how much a regex can impact search time.
+    ///
+    /// The default for this is some reasonable number that permits most
+    /// patterns to compile successfully.
+    pub size_limit: Option<usize>,
+
+    /// Set the approximate capacity, in bytes, of the cache of transitions
+    /// used by the lazy DFA.
+    ///
+    /// While the lazy DFA isn't always used, in tends to be the most
+    /// commonly use regex engine in default configurations. It tends to
+    /// adopt the performance profile of a fully build DFA, but without the
+    /// downside of taking worst case exponential time to build.
+    ///
+    /// The downside is that it needs to keep a cache of transitions and
+    /// states that are built while running a search, and this cache
+    /// can fill up. When it fills up, the cache will reset itself. Any
+    /// previously generated states and transitions will then need to be
+    /// re-generated. If this happens too many times, then this library
+    /// will bail out of using the lazy DFA and switch to a different regex
+    /// engine.
+    ///
+    /// If your regex provokes this particular downside of the lazy DFA,
+    /// then it may be beneficial to increase its cache capacity. This will
+    /// potentially reduce the frequency of cache resetting (ideally to
+    /// `0`). While it won't fix all potential performance problems with
+    /// the lazy DFA, increasing the cache capacity does fix some.
+    ///
+    /// There is no easy way to determine, a priori, whether increasing
+    /// this cache capacity will help. In general, the larger your regex,
+    /// the more cache it's likely to use. But that isn't an ironclad rule.
+    /// For example, a regex like `[01]*1[01]{N}` would normally produce a
+    /// fully build DFA that is exponential in size with respect to `N`.
+    /// The lazy DFA will prevent exponential space blow-up, but it cache
+    /// is likely to fill up, even when it's large and even for smallish
+    /// values of `N`.
+    ///
+    /// If you aren't sure whether this helps or not, it is sensible to
+    /// set this to some arbitrarily large number in testing, such as
+    /// `usize::MAX`. Namely, this represents the amount of capacity that
+    /// *may* be used. It's probably not a good idea to use `usize::MAX` in
+    /// production though, since it implies there are no controls on heap
+    /// memory used by this library during a search. In effect, set it to
+    /// whatever you're willing to allocate for a single regex search.
+    pub dfa_size_limit: Option<usize>,
+}
+
+/// Regex implementations with options
+#[derive(Clone)]
+pub enum RegexEngine {
+    FancyRegex(FancyRegexOptions),
+    Regex(RegexOptions),
+}
+
+impl Default for RegexEngine {
+    fn default() -> Self {
+        RegexEngine::FancyRegex(FancyRegexOptions::default())
+    }
+}
+
 /// Full configuration to guide the `JSONSchema` compilation.
 ///
 /// Using a `CompilationOptions` instance you can configure the supported draft,
@@ -278,6 +379,7 @@ pub struct CompilationOptions {
     validate_schema: bool,
     ignore_unknown_formats: bool,
     keywords: AHashMap<String, Arc<dyn KeywordFactory>>,
+    patterns_regex_engine: RegexEngine,
 }
 
 impl Default for CompilationOptions {
@@ -293,6 +395,7 @@ impl Default for CompilationOptions {
             validate_formats: None,
             ignore_unknown_formats: true,
             keywords: AHashMap::default(),
+            patterns_regex_engine: Default::default(),
         }
     }
 }
@@ -428,6 +531,30 @@ impl CompilationOptions {
     pub fn without_content_media_type_support(&mut self, media_type: &'static str) -> &mut Self {
         self.content_media_type_checks.insert(media_type, None);
         self
+    }
+
+    /// Use specific regex engine with options for patterns.
+    ///
+    /// Available engines:
+    ///  - [RegexEngine::Regex] - An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. https://github.com/rust-lang/regex
+    ///  - [RegexEngine::FancyRegex] - Rust library for regular expressions using "fancy" features like look-around and backreferences. https://github.com/fancy-regex/fancy-regex
+    ///
+    /// Default: [RegexEngine::FancyRegex]
+    ///
+    /// ```rust
+    /// # use jsonschema::CompilationOptions;
+    /// # use jsonschema::RegexEngine;
+    /// # let mut options = CompilationOptions::default();
+    /// // Set Regex as a default engine for pattern keyword
+    /// options.with_patterns_regex_engine(RegexEngine::Regex(Default::default()));
+    /// ```
+    pub fn with_patterns_regex_engine(&mut self, regex_engine: RegexEngine) -> &mut Self {
+        self.patterns_regex_engine = regex_engine;
+        self
+    }
+
+    pub(crate) fn pattern_regex_engine(&self) -> &RegexEngine {
+        &self.patterns_regex_engine
     }
 
     #[inline]

--- a/jsonschema/src/compilation/options.rs
+++ b/jsonschema/src/compilation/options.rs
@@ -542,11 +542,10 @@ impl CompilationOptions {
     /// Default: [RegexEngine::FancyRegex]
     ///
     /// ```rust
-    /// # use jsonschema::CompilationOptions;
-    /// # use jsonschema::RegexEngine;
-    /// # let mut options = CompilationOptions::default();
+    /// use jsonschema::{CompilationOptions, RegexEngine, RegexOptions};
+    /// let mut options = CompilationOptions::default();
     /// // Set Regex as a default engine for pattern keyword
-    /// options.with_patterns_regex_engine(RegexEngine::Regex(Default::default()));
+    /// options.with_patterns_regex_engine(RegexEngine::Regex(RegexOptions::default()));
     /// ```
     pub fn with_patterns_regex_engine(&mut self, regex_engine: RegexEngine) -> &mut Self {
         self.patterns_regex_engine = regex_engine;

--- a/jsonschema/src/keywords/format.rs
+++ b/jsonschema/src/keywords/format.rs
@@ -302,7 +302,7 @@ impl Validate for RegexValidator {
     validate!("regex");
     fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
-            pattern::convert_regex(item, self.config.pattern_regex_engine()).is_ok()
+            pattern::convert_regex(item, self.config.patterns_regex_engine()).is_ok()
         } else {
             true
         }

--- a/jsonschema/src/keywords/pattern.rs
+++ b/jsonschema/src/keywords/pattern.rs
@@ -32,7 +32,7 @@ impl PatternValidator {
     ) -> CompilationResult<'a> {
         match pattern {
             Value::String(item) => {
-                let pattern = match convert_regex(item, context.config.pattern_regex_engine()) {
+                let pattern = match convert_regex(item, context.config.patterns_regex_engine()) {
                     Ok(r) => r,
                     Err(_) => {
                         return Err(ValidationError::format(

--- a/jsonschema/src/keywords/pattern.rs
+++ b/jsonschema/src/keywords/pattern.rs
@@ -5,6 +5,8 @@ use crate::{
     paths::JsonPointerNode,
     primitive_type::PrimitiveType,
     validator::Validate,
+    RegexEngine,
+    regex::{Regex, RegexError}
 };
 use once_cell::sync::Lazy;
 use serde_json::{Map, Value};
@@ -18,7 +20,7 @@ static CONTROL_GROUPS_RE: Lazy<regex::Regex> =
 
 pub(crate) struct PatternValidator {
     original: String,
-    pattern: fancy_regex::Regex,
+    pattern: Regex,
     schema_path: JSONPointer,
 }
 
@@ -30,7 +32,7 @@ impl PatternValidator {
     ) -> CompilationResult<'a> {
         match pattern {
             Value::String(item) => {
-                let pattern = match convert_regex(item) {
+                let pattern = match convert_regex(item, context.config.pattern_regex_engine()) {
                     Ok(r) => r,
                     Err(_) => {
                         return Err(ValidationError::format(
@@ -76,11 +78,15 @@ impl Validate for PatternValidator {
                     }
                 }
                 Err(e) => {
+                    let RegexError::FancyRegex(fancy_error) = e else {
+                        unreachable!("Only fancy regex returns an error")
+                    };
+
                     return error(ValidationError::backtrack_limit(
                         self.schema_path.clone(),
                         instance_path.into(),
                         instance,
-                        e,
+                        fancy_error,
                     ));
                 }
             }
@@ -104,7 +110,7 @@ impl core::fmt::Display for PatternValidator {
 
 // ECMA 262 has differences
 #[allow(clippy::result_large_err)]
-pub(crate) fn convert_regex(pattern: &str) -> Result<fancy_regex::Regex, fancy_regex::Error> {
+pub(crate) fn convert_regex(pattern: &str, regex_engine: &RegexEngine) -> Result<Regex, RegexError> {
     // replace control chars
     let new_pattern = CONTROL_GROUPS_RE.replace_all(pattern, replace_control_group);
     let mut out = String::with_capacity(new_pattern.len());
@@ -143,7 +149,7 @@ pub(crate) fn convert_regex(pattern: &str) -> Result<fancy_regex::Regex, fancy_r
             out.push(current);
         }
     }
-    fancy_regex::Regex::new(&out)
+    Regex::new(&out, regex_engine)
 }
 
 #[allow(clippy::arithmetic_side_effects)]
@@ -186,7 +192,8 @@ mod tests {
     #[test_case(r"^\W+$", "1_0", false)]
     #[test_case(r"\\w", r"\w", true)]
     fn regex_matches(pattern: &str, text: &str, is_matching: bool) {
-        let compiled = convert_regex(pattern).expect("A valid regex");
+        let regex_engine = RegexEngine::FancyRegex(Default::default());
+        let compiled = convert_regex(pattern, &regex_engine).expect("A valid regex");
         assert_eq!(
             compiled.is_match(text).expect("A valid pattern"),
             is_matching
@@ -196,7 +203,8 @@ mod tests {
     #[test_case(r"\")]
     #[test_case(r"\d\")]
     fn invalid_escape_sequences(pattern: &str) {
-        assert!(convert_regex(pattern).is_err())
+        let regex_engine = RegexEngine::FancyRegex(Default::default());
+        assert!(convert_regex(pattern, &regex_engine).is_err())
     }
 
     #[test_case("^(?!eo:)", "eo:bands", false)]

--- a/jsonschema/src/keywords/pattern_properties.rs
+++ b/jsonschema/src/keywords/pattern_properties.rs
@@ -26,7 +26,7 @@ impl PatternPropertiesValidator {
         for (pattern, subschema) in map {
             let pattern_context = keyword_context.with_path(pattern.as_str());
             patterns.push((
-                match Regex::new(pattern, context.config.pattern_regex_engine()) {
+                match Regex::new(pattern, context.config.patterns_regex_engine()) {
                     Ok(r) => r,
                     Err(_) => {
                         return Err(ValidationError::format(
@@ -137,7 +137,7 @@ impl SingleValuePatternPropertiesValidator {
         let keyword_context = context.with_path("patternProperties");
         let pattern_context = keyword_context.with_path(pattern);
         Ok(Box::new(SingleValuePatternPropertiesValidator {
-            pattern: match Regex::new(pattern, context.config.pattern_regex_engine()) {
+            pattern: match Regex::new(pattern, context.config.patterns_regex_engine()) {
                 Ok(r) => r,
                 Err(_) => {
                     return Err(ValidationError::format(

--- a/jsonschema/src/keywords/pattern_properties.rs
+++ b/jsonschema/src/keywords/pattern_properties.rs
@@ -8,8 +8,8 @@ use crate::{
     schema_node::SchemaNode,
     validator::{format_validators, PartialApplication, Validate},
 };
-use fancy_regex::Regex;
 use serde_json::{Map, Value};
+use crate::regex::Regex;
 
 pub(crate) struct PatternPropertiesValidator {
     patterns: Vec<(Regex, SchemaNode)>,
@@ -26,7 +26,7 @@ impl PatternPropertiesValidator {
         for (pattern, subschema) in map {
             let pattern_context = keyword_context.with_path(pattern.as_str());
             patterns.push((
-                match Regex::new(pattern) {
+                match Regex::new(pattern, context.config.pattern_regex_engine()) {
                     Ok(r) => r,
                     Err(_) => {
                         return Err(ValidationError::format(
@@ -137,7 +137,7 @@ impl SingleValuePatternPropertiesValidator {
         let keyword_context = context.with_path("patternProperties");
         let pattern_context = keyword_context.with_path(pattern);
         Ok(Box::new(SingleValuePatternPropertiesValidator {
-            pattern: match Regex::new(pattern) {
+            pattern: match Regex::new(pattern, context.config.pattern_regex_engine()) {
                 Ok(r) => r,
                 Err(_) => {
                     return Err(ValidationError::format(

--- a/jsonschema/src/lib.rs
+++ b/jsonschema/src/lib.rs
@@ -96,8 +96,9 @@ mod resolver;
 mod schema_node;
 mod schemas;
 mod validator;
+mod regex;
 
-pub use compilation::{options::CompilationOptions, JSONSchema};
+pub use compilation::{options::CompilationOptions, JSONSchema, options::RegexEngine, options::RegexOptions, options::FancyRegexOptions};
 pub use error::{ErrorIterator, ValidationError};
 pub use keywords::custom::Keyword;
 pub use resolver::{SchemaResolver, SchemaResolverError};

--- a/jsonschema/src/properties.rs
+++ b/jsonschema/src/properties.rs
@@ -1,5 +1,5 @@
 use ahash::AHashMap;
-use fancy_regex::Regex;
+use crate::regex::Regex;
 use serde_json::{Map, Value};
 
 use crate::{
@@ -144,7 +144,7 @@ pub(crate) fn compile_patterns<'a>(
     let mut compiled_patterns = Vec::with_capacity(obj.len());
     for (pattern, subschema) in obj {
         let pattern_context = keyword_context.with_path(pattern.as_str());
-        if let Ok(compiled_pattern) = Regex::new(pattern) {
+        if let Ok(compiled_pattern) = Regex::new(pattern, context.config.pattern_regex_engine()) {
             let node = compile_validators(subschema, &pattern_context)?;
             compiled_patterns.push((compiled_pattern, node));
         } else {

--- a/jsonschema/src/properties.rs
+++ b/jsonschema/src/properties.rs
@@ -144,7 +144,7 @@ pub(crate) fn compile_patterns<'a>(
     let mut compiled_patterns = Vec::with_capacity(obj.len());
     for (pattern, subschema) in obj {
         let pattern_context = keyword_context.with_path(pattern.as_str());
-        if let Ok(compiled_pattern) = Regex::new(pattern, context.config.pattern_regex_engine()) {
+        if let Ok(compiled_pattern) = Regex::new(pattern, context.config.patterns_regex_engine()) {
             let node = compile_validators(subschema, &pattern_context)?;
             compiled_patterns.push((compiled_pattern, node));
         } else {

--- a/jsonschema/src/regex.rs
+++ b/jsonschema/src/regex.rs
@@ -1,0 +1,80 @@
+use std::fmt::Display;
+use crate::compilation::options::RegexEngine;
+
+#[derive(Debug)]
+pub enum RegexError {
+    Regex(regex::Error),
+    FancyRegex(fancy_regex::Error),
+}
+
+impl Display for RegexError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RegexError::Regex(e) => write!(f, "{}", e),
+            RegexError::FancyRegex(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Regex {
+    Regex(regex::Regex),
+    FancyRegex(fancy_regex::Regex),
+}
+
+impl Display for Regex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Regex::Regex(r) => write!(f, "{}", r),
+            Regex::FancyRegex(r) => write!(f, "{}", r),
+        }
+    }
+}
+
+impl Regex {
+    pub fn new(pattern: &str, regex_engine: &RegexEngine) -> Result<Self, RegexError> {
+        match regex_engine {
+            RegexEngine::Regex(options) => {
+                let mut builder  = &mut regex::RegexBuilder::new(pattern);
+
+                if let Some(size_limit) = options.size_limit {
+                    builder = builder.size_limit(size_limit);
+                }
+
+                if let Some(dfa_size_limit) = options.dfa_size_limit {
+                    builder = builder.dfa_size_limit(dfa_size_limit);
+                }
+
+                builder.build()
+                    .map(Regex::Regex)
+                    .map_err(RegexError::Regex)
+            },
+            RegexEngine::FancyRegex(options) => {
+                let mut builder  = &mut fancy_regex::RegexBuilder::new(pattern);
+
+                if let Some(backtrack_limit) = options.backtrack_limit {
+                    builder = builder.backtrack_limit(backtrack_limit);
+                }
+
+                if let Some(delegate_size_limit) = options.delegate_size_limit {
+                    builder = builder.delegate_size_limit(delegate_size_limit);
+                }
+
+                if let Some(delegate_dfa_size_limit) = options.delegate_dfa_size_limit {
+                    builder = builder.delegate_dfa_size_limit(delegate_dfa_size_limit);
+                }
+
+                builder.build()
+                    .map(Regex::FancyRegex)
+                    .map_err(RegexError::FancyRegex)
+            },
+        }
+    }
+
+    pub fn is_match(&self, text: &str) -> Result<bool, RegexError> {
+        match self {
+            Regex::Regex(r) => Ok(r.is_match(text)),
+            Regex::FancyRegex(r) => r.is_match(text).map_err(RegexError::FancyRegex),
+        }
+    }
+}


### PR DESCRIPTION
Fancy Regex supports backtracking which is required for some cases but as a downside is vulnerable for ReDoS attacks. This becomes a decisive factor when an application operates with user defined schemas. Regex, in turn, doesn't support most of look back patterns but guarantees linear time matching that mitigates the attack.

This PR enables configuration of regex engine for pattern based keywords: Regex or FancyRegex (by default).

`format` still uses Fancy Regex. Probably, it make sense to provide an option to use simple/fast format validation such as [ajv-formats](https://github.com/ajv-validator/ajv-formats) but this out of scope of this PR. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting and configuring different regex engines for pattern matching, including new options for engine-specific limits.
  * Exposed new configuration options for regex behavior in schema compilation.
  * Introduced a unified regex abstraction, allowing users to choose between standard and advanced regex engines.

* **Bug Fixes**
  * Improved consistency and error handling in pattern and format validators by standardizing regex usage across the library.

* **Documentation**
  * Enhanced documentation for new regex configuration options and their effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->